### PR TITLE
DoH in Firefox is US-only currently

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -46,7 +46,7 @@
           </tr>
             <tr>
               <th scope="row">Sends every domain you visit to Cloudflare</th>
-              <td><a href="https://twitter.com/PowerDNS_Bert/status/1170638582471675906" target="_blank">Yes!</a></td>
+              <td><a href="https://twitter.com/PowerDNS_Bert/status/1170638582471675906" target="_blank">Yes!</a> (US-only)</td>
               <td>No.</td>
             </tr>
           </tbody>


### PR DESCRIPTION
Some things:
* it's currently US-only (I think this is good to mention there, at least, as they search and wanted other DoH providers/servers for Europe e.g., too.)
* it's some kind of staged rollout
* it is sometimes disabled automatically in cases like parental control etc.

All that is described in https://blog.mozilla.org/futurereleases/2019/09/06/whats-next-in-making-dns-over-https-the-default/, so IMHO the last two points are not big things to mention on such a small table/summary website, but at least that it is restricted to one country in the world is a big point IMHO that sho0uld be mentioned in such a short summary. We have a lot of countries in the world, after all and this website has an international target audience.