### PR TITLE
Add row for ublock extension incompatibilty

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -49,6 +49,11 @@
               <td><a href="https://twitter.com/PowerDNS_Bert/status/1170638582471675906" target="_blank">Yes!</a></td>
               <td>No.</td>
             </tr>
+            <tr>
+              <th scope="row">Is incompatible with privacy-saving extensions like uBlock Origin</th>
+              <td>No.</td>
+              <td><a href="https://www.bleepingcomputer.com/news/security/chrome-extension-manifest-v3-may-break-ublock-origin-content-blocker/" target="_blank">Yes!</a></td>
+            </tr>
           </tbody>
           <tfoot class="thead-inverse">
               <tr>

--- a/www/index.html
+++ b/www/index.html
@@ -50,7 +50,7 @@
               <td>No.</td>
             </tr>
             <tr>
-              <th scope="row">Is incompatible with privacy-saving extensions like uBlock Origin</th>
+              <th scope="row">Prevents anti-tracking and anti-ad extensions like uBlock Origin from working fully</th>
               <td>No.</td>
               <td><a href="https://www.bleepingcomputer.com/news/security/chrome-extension-manifest-v3-may-break-ublock-origin-content-blocker/" target="_blank">Yes!</a></td>
             </tr>


### PR DESCRIPTION
Chrome has made a change in their webextension exposed APIs, removing the ability to block requests by a webextension, so ublock and others cannot save your privacy. Smart move from google to make sure you see google ads.